### PR TITLE
fix: NameError on cd hook — xonsh name never imported

### DIFF
--- a/xontrib/mise.py
+++ b/xontrib/mise.py
@@ -69,7 +69,7 @@ def listen_cmd_pos(cmd:str, rtn:int, out:str or None, ts:list, **_):
 def update_env():
   ctx = XSH.ctx
 
-  mise_hook_proc  = subprocess.run([bin,'hook-env','-s','xonsh'],capture_output=True, env=xonsh.environ.XSH.env.detype_all())
+  mise_hook_proc  = subprocess.run([bin,'hook-env','-s','xonsh'],capture_output=True, env=XSH.env.detype_all())
   mise_hook       = mise_hook_proc.stdout # ↑ set $__MISE_DIR, $__MISE_DIFF, $__MISE_WATCH
   mise_hook_err   = mise_hook_proc.stderr
 


### PR DESCRIPTION
update_env() referenced xonsh.environ.XSH but only XSH was imported via 'from xonsh.built_ins import XSH'. Fires on every cd (listen_cd), breaking the xontrib. Use the already-imported XSH directly.

Hi! Thank you for the awesome xontrib! I gave it a star!

Please take a look at my PR that ...

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
